### PR TITLE
16 task templates change

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic-template.yml
+++ b/.github/ISSUE_TEMPLATE/epic-template.yml
@@ -31,16 +31,6 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: related_epics
-    attributes:
-      label: Related Epics
-      description: List any related epics if applicable. Add each related epic as a link or reference number on a new line.
-      placeholder: |
-        - [ ] #
-    validations:
-      required: false
-
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/story-template.yml
+++ b/.github/ISSUE_TEMPLATE/story-template.yml
@@ -18,16 +18,6 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: epic_reference
-    attributes:
-      label: Epic Reference
-      description: Link to the associated Epic that this story belongs to.
-      placeholder: |
-        #
-    validations:
-      required: false
-
   - type: dropdown
     id: priority
     attributes:

--- a/.github/ISSUE_TEMPLATE/task-template.yml
+++ b/.github/ISSUE_TEMPLATE/task-template.yml
@@ -31,17 +31,6 @@ body:
     validations:
       required: true
 
-
-  - type: textarea
-    id: story_reference
-    attributes:
-      label: Story Reference
-      description: Link to the associated Story.
-      placeholder: |
-        #
-    validations:
-      required: false
-
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
This pull request includes changes to the issue templates in the `.github/ISSUE_TEMPLATE` directory. The main focus is the removal of certain fields from the epic, story, and task templates.

Changes to issue templates:

* [`.github/ISSUE_TEMPLATE/epic-template.yml`](diffhunk://#diff-3ddf7ebf516fca23038f72a2faaf73b9e98d0150bf211907572bd6efd5862669L34-L43): Removed the `related_epics` textarea field.
* [`.github/ISSUE_TEMPLATE/story-template.yml`](diffhunk://#diff-a450ddba7de6bfa3730da594656180b630a387c7d29037e04ccdf71e1f158909L21-L30): Removed the `epic_reference` textarea field.
* [`.github/ISSUE_TEMPLATE/task-template.yml`](diffhunk://#diff-92742d3ae9e003d4743c400894d4c860332eff902fa69832d55699f8a4ad0887L34-L44): Removed the `story_reference` textarea field.
